### PR TITLE
feature/nft-minting: add NFT and IPFS support, added glamora-nft.clar and sip-009.clar

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -6,8 +6,18 @@ telemetry = true
 cache_dir = '.\.cache'
 requirements = []
 
+[contracts.glamora-nft]
+path = 'contracts/glamora-nft.clar'
+clarity_version = 3
+epoch = 3.0
+
 [contracts.main]
 path = 'contracts/main.clar'
+clarity_version = 3
+epoch = 3.0
+
+[contracts.sip-009]
+path = 'contracts/sip-009.clar'
 clarity_version = 3
 epoch = 3.0
 
@@ -15,7 +25,6 @@ epoch = 3.0
 path = 'contracts/storage.clar'
 clarity_version = 3
 epoch = 3.0
-
 [repl.analysis]
 passes = ['check_checker']
 

--- a/contracts/glamora-nft.clar
+++ b/contracts/glamora-nft.clar
@@ -1,0 +1,119 @@
+;; title: glamora-nft
+
+;; summary:Glamora Fashion Platform NFT Contract that complies with SIP-009 
+
+;; description: This is the main NFT contract for the Glamora fashion platform that handles minting,
+;; trading, and managing fashion-related NFTs. It Implements the SIP-009 standard to ensure
+;; compatibility with NFT marketplaces and wallets. 
+
+;; version: 3.0
+
+;; author: "Timothy Terese Chimbiv"
+
+;; Let's implement the trait we defined
+(impl-trait .sip-009.nft-trait)
+
+;;========================================
+;; ERROR CODES
+;;========================================
+
+(define-constant ERR-NOT-NFT-OWNER (err u202)) ;; The caller is not the owner of this NFT
+(define-constant ERR-TRANSFER-FAILED (err u207)) ;; When STX or NFT transfer operation fails
+
+;;========================================
+;; PLATFORM STATE VARIABLES
+;;========================================
+
+;; this function will keep track of the total NFTs that's been minted, 
+;; initially starts at 0 and increases with each new mint
+(define-data-var total-nfts-minted uint u0)  
+
+;;=======================================
+;; NFT TOKEN DEFINITION
+;;=======================================
+
+;; This will create "glamora-nft" tokens, each one is unique and gets its own ID number
+(define-non-fungible-token glamora-nft uint)
+
+;;=======================================
+;; SIP-009 TRAIT IMPLEMENTATION
+;;=======================================
+
+;; GET LAST TOKEN ID
+;; @desc: This will tell us how many NFTs minted by giving the first NFT minted #1 
+;; and the next after that one #2, then #3, #4, and so on
+;; So if we've minted 5 NFTs, this returns 5 (which is also the last token ID)
+(define-read-only (get-last-token-id)
+    (ok (var-get total-nfts-minted))
+)
+;; get-last-token-id will return total-nfts-minted which is perfect because 
+;; it tells us the highest NFT ID that exists
+
+;; GET TOKEN URI
+;; @desc: This function will get the web link where NFT details are stored like getting a website URL
+;; If the NFT exists by the number that was inputted (token-id) 
+;; then it returns IPFS hash and the wallets can show the picture
+(define-read-only (get-token-uri (token-id uint))
+    (match (contract-call? .storage get-nft-metadata token-id) 
+        nft-data (ok (some (concat "ipfs://" (get image-ipfs-hash nft-data)))) 
+    (ok none))
+)
+
+;; GET OWNER
+;; @desc: This function tells us who owns a specific NFT by giving it an NFT ID number like #1, #2, #3
+;; It will check our NFT ownership records and returns the wallet address of whoever owns that NFT
+;; and eturns none if the NFT doesn't exist
+(define-read-only (get-owner (token-id uint))
+    (ok (nft-get-owner? glamora-nft token-id))
+)
+
+;;=======================================
+;; READ-ONLY FUNCTIONS
+;;=======================================
+
+;; GET TOTAL NFTS MINTED
+;; @desc: this function will show how many NFTs that's been minted so far on the platform
+(define-read-only (get-total-nfts-minted)
+    (var-get total-nfts-minted)
+)
+
+;; TRANSFER
+;;  @desc: This functions ensures the moving of an NFT from one wallet to another
+;; and only the current owner of the NFT can initiate this transfer.
+;; @param:
+;; - token id 
+;; - sender 
+;; - recipient
+(define-public (transfer (token-id uint) (sender principal) (recipient principal))
+    (begin
+        ;; Check that the person transfering (must be the tx-sender) is the owner of the
+        ;; NFT so people don't transfer NFT they don't own
+        (asserts! (is-eq tx-sender sender) ERR-NOT-NFT-OWNER)
+
+        ;;Transfer NFT to recipient and unwrap! stops the function's execution 
+        ;; and returns an error if transfer fails
+        (unwrap! (nft-transfer? glamora-nft token-id sender recipient) ERR-TRANSFER-FAILED)
+
+        ;; transfer event log, so everyone can see what happened
+        (print {
+            event: "nft-transferred",
+            token-id: token-id,
+            sender: sender,
+            recipient: recipient
+        })
+        
+        (ok true)
+    )
+)
+
+
+
+
+
+
+
+
+
+
+
+

--- a/contracts/main.clar
+++ b/contracts/main.clar
@@ -270,6 +270,15 @@
     (contract-call? .storage get-creator-subscription-stats creator)
 )
 
+;;=======================================
+;; GET NFT-METADTA READ-ONLY 
+;;=======================================
+;; @desc: This function bridges the main contract to the storage contract to fetch NFT metadata
+;; We call our storage contract to fetch the NFT metadata providing it a token id
+(define-read-only (get-nft-metadata (token-id uint))
+    (contract-call? .storage get-nft-metadata token-id)
+)
+
 ;; ==========================
 ;; This is what the flow looks like => user calls main, main queries storage, and storage returns the result for the user
 ;; ============================
@@ -423,12 +432,15 @@
 ;; (e.g., posting, tipping) so no full off-chain storage system is required for now
 ;; Later, glamora will use IPFS to store content and point content-hash to those files on the decentralized storage
 
+;; ENHANCEMENT:
+;; Added IPFS-HASH parameter so users can input their ipfs-hash if they have one
+
 ;; @param
 ;; - title (string-utf8 64)
 ;; - description (string-utf8 256)
 ;; - content-hash (buff 32)
 ;; - category uint
-(define-public (publish-content (title (string-utf8 64)) (description (string-utf8 256)) (content-hash (buff 32)) (category uint))
+(define-public (publish-content (title (string-utf8 64)) (description (string-utf8 256)) (content-hash (buff 32)) (ipfs-hash (optional (string-ascii 64))) (category uint))
     (let
         (
             ;; we need to get the ID number that the next post will get
@@ -454,6 +466,7 @@
                     title
                     description
                     content-hash
+                    ipfs-hash ;; added for enhancement
                     category
                 ) 
                 ERR-TRANSFER-FAILED
@@ -472,7 +485,8 @@
             content-id: content-id,           ;; The post's unique ID number
             creator: tx-sender,               ;; Who created it
             category: category,               ;; What type of content is it
-            title: title     
+            title: title,
+            ipfs: ipfs-hash     
         })
 
         (ok content-id) ;; return the content ID to the user

--- a/contracts/sip-009.clar
+++ b/contracts/sip-009.clar
@@ -1,0 +1,32 @@
+;; title: sip-009
+
+;; summary: This is SIP-009 NFT Standard Trait Definition for Glamora Fashion Platform
+
+;; description: This contract defines the standard SIP-009 NFT trait
+;; interface to work with traits properly with NFT market places, crypto wallets and
+;; and any platform that displays NFTs,
+;; without following this standard, it won't be recognized or tradeable.
+
+;; version: 3.0
+
+;; author: "Timothy Terese Chimbiv"
+
+;;=======================================
+;; SIP-009 NFT TRAIT DEFINITION
+;;=======================================
+
+(define-trait nft-trait
+    (
+        ;; Get the last token ID that was minted
+        (get-last-token-id () (response uint uint))
+        
+        ;; Get the metadata URI for a specific token
+        (get-token-uri (uint) (response (optional (string-ascii 256)) uint))
+        
+        ;; Get the owner of a specific token
+        (get-owner (uint) (response (optional principal) uint))
+        
+        ;; Transfer a token from sender to recipient
+        (transfer (uint principal principal) (response bool uint))
+    )
+)

--- a/contracts/storage.clar
+++ b/contracts/storage.clar
@@ -99,6 +99,7 @@
     title: (string-utf8 64),
     description: (string-utf8 256),
     content-hash: (buff 32),
+    ipfs-hash: (optional (string-ascii 64)), ;; ipfs added
     category: uint,
     creation-date: uint,
     tip-count: uint,
@@ -118,6 +119,19 @@
 (define-map user-follows {follower: principal, following: principal} {
     follow-date: uint,
     active: bool
+})
+
+;;=======================================
+;; NEW NFT-METADATA STORAGE MAP 
+;;=======================================
+;; @desc: This map stores all the detailed information about each NFT that was minted
+(define-map nft-metadata uint {
+    name: (string-utf8 64),
+    description: (string-utf8 256),
+    image-ipfs-hash: (string-ascii 64),
+    animation-ipfs-hash: (optional (string-ascii 64)),
+    external-url: (optional (string-ascii 128)),
+    attributes-ipfs-hash: (optional (string-ascii 64))
 })
 
 ;;================================
@@ -248,6 +262,16 @@
         ;; Two possible outcomes to handle here. If something is found or nothing at all
         (match follow-data data (get active data) false) ;; the none branch return false if we have no data
     )
+)
+
+;;=======================================
+;; NEW GET NFT-METADATA READ-ONLY FUNCTION
+;;=======================================
+;; @desc: This function will fetch all the detailed information about a specific NFT
+;; by giving it an NFT ID number, it looks in our nft-metadata map using that ID as the key
+;; and return the information if found or nothing if NFT does not exist
+(define-read-only (get-nft-metadata (token-id uint))
+    (map-get? nft-metadata token-id)
 )
 
 ;;===================================================
@@ -391,14 +415,16 @@
 ;; - creator principal
 ;; - (title (string-utf8 64))              
 ;; - (description (string-utf8 256))       
-;; - (content-hash (buff 32))              
+;; - (content-hash (buff 32))   
+;; - (ipfs-hash (optional (string-ascii 64))) added the ipfs parameter ensure decentralized sotrage           
 ;; - (category uint)
 (define-public (create-content 
     (content-id uint) 
     (creator principal) 
     (title (string-utf8 64)) 
     (description (string-utf8 256)) 
-    (content-hash (buff 32)) 
+    (content-hash (buff 32))
+    (ipfs-hash (optional (string-ascii 64)))  
     (category uint)) 
     (let
         (
@@ -417,7 +443,8 @@
             creator: creator,
             title: title,                     
             description: description,         
-            content-hash: content-hash,       
+            content-hash: content-hash, 
+            ipfs-hash: ipfs-hash,      
             category: category,               
             creation-date: stacks-block-height, 
             tip-count: u0,                    


### PR DESCRIPTION
Added glamora-nft.clar and sip-009.clar for SIP-009 compliant NFTs
- In main.clar: added get-nft-metadata read-only, ipfs-hash to publish-content
- In storage.clar: added nft-metadata map, read-only, ipfs-hash to content-registry
- and formatted Clarinet.toml with proper spacing