### PR TITLE
feat: add sBTC balance display alongside USDCx balance

### DIFF
--- a/glamora-frontend/src/components/UsdcxTipping.jsx
+++ b/glamora-frontend/src/components/UsdcxTipping.jsx
@@ -36,6 +36,7 @@ const UsdcxTipping = ({ userAddress, userProfile }) => {
   // ============================================================
   
   const [balance, setBalance] = useState(0);
+  const [sbtcBalance, setSbtcBalance] = useState(0);
   const [balanceHighlight, setBalanceHighlight] = useState(false);
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState('');
@@ -52,6 +53,7 @@ const UsdcxTipping = ({ userAddress, userProfile }) => {
   useEffect(() => {
     if (userAddress) {
       loadBalance();
+      loadSbtcBalance();
       loadVaultInfo();
       loadBatchStats();
     }
@@ -64,6 +66,16 @@ const UsdcxTipping = ({ userAddress, userProfile }) => {
       console.log('USDCx Balance loaded:', formatUSDCxAmount(microBalance), 'USDCx');
     } catch (error) {
       console.error('Error loading balance:', error);
+    }
+  };
+
+  const loadSbtcBalance = async () => {
+    try {
+      const result = await contractCalls.getSbtcBalance(userAddress);
+      setSbtcBalance(result);
+      console.log('sBTC Balance loaded:', result, 'sBTC');
+    } catch (error) {
+      console.error('Error loading sBTC balance:', error);
     }
   };
 
@@ -124,7 +136,6 @@ const UsdcxTipping = ({ userAddress, userProfile }) => {
       setLoading(false);
     }
   };
-
 
    //============================================================
    // TIPPING LOGIC - USDCx
@@ -260,6 +271,10 @@ const UsdcxTipping = ({ userAddress, userProfile }) => {
               <span className="balance-label">USDCx Balance</span>
               <span className={`balance-amount ${balanceHighlight ? 'updated' : ''}`}>
                 {formatUSDCxAmount(balance)} USDCx
+              </span>
+              <span className="balance-label">sBTC BALANCE</span>
+              <span className="balance-amount">
+                {sbtcBalance.toFixed(8)} sBTC
               </span>
             </div>
             <div className="balance-actions">

--- a/glamora-frontend/src/contractCalls.js
+++ b/glamora-frontend/src/contractCalls.js
@@ -499,11 +499,27 @@ export const mintTestUSDCx = async (amount, recipient) => {
 };
 
 export const getUSDCxBalance = async (address) => {
-  return await readOnly(
+  const result = await readOnly(
     CONTRACTS.USDCX_TOKEN.name,
     USDCX_FUNCTIONS.GET_BALANCE,
     [principalCV(address)]
   );
+  if (result && typeof result === 'object' && result.value !== undefined) {
+    return Number(result.value);
+  }
+  return Number(result) || 0;
+};
+
+export const getSbtcBalance = async (address) => {
+  const result = await readOnly(
+    CONTRACTS.SBTC_TOKEN.name,
+    'get-balance',
+    [principalCV(address)]
+  );
+  if (result && typeof result === 'object' && result.value !== undefined) {
+    return Number(result.value) / 100000000;
+  }
+  return 0;
 };
 
 // ============================================================


### PR DESCRIPTION
The fix:
- Added sBTC balance display in Send Tip page alongside USDCx balance
- Both balances load on wallet connect and refresh together
- getSbtcBalance function added to contractCalls.js
- loadSbtcBalance added to UsdcxTipping component